### PR TITLE
meta can contain spaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "gemini-fetch"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gemini-fetch"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Jay Vana <jaysvana@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ impl FromStr for Header {
     type Err = ParseHeaderError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts: Vec<&str> = s.trim().split(' ').collect();
+        let parts: Vec<&str> = s.trim().splitn(2, ' ').collect();
 
         let status: Status = parts
             .get(0)


### PR DESCRIPTION
Fixes header parsing if the meta part contains spaces.